### PR TITLE
Task data chan get closed before all consumer routines are closed fixed

### DIFF
--- a/kafka/adaptors/librd/producer.go
+++ b/kafka/adaptors/librd/producer.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	librdKafka "github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/gmbyapa/kstream/v2/kafka"
-	"github.com/gmbyapa/kstream/v2/kafka/adaptors/sarama"
 	"github.com/gmbyapa/kstream/v2/pkg/errors"
 	"github.com/tryfix/log"
 	"github.com/tryfix/metrics"
@@ -48,7 +47,6 @@ type librdProducer struct {
 	mu *sync.RWMutex
 
 	partitionCounts *sync.Map
-	adminClient     kafka.Admin
 }
 
 type producerProvider struct {
@@ -87,12 +85,6 @@ func NewProducer(configs *ProducerConfig) (kafka.Producer, error) {
 		return nil, errors.Wrap(err, `invalid producer configs`)
 	}
 
-	// Create an admin client to fetch topic metadata
-	admin, err := sarama.NewAdmin(configs.BootstrapServers)
-	if err != nil {
-		return nil, errors.Wrap(err, `metadata fetch failed`)
-	}
-
 	loggerPrefix := `Producer`
 	if configs.Transactional.Enabled {
 		loggerPrefix = `TransactionalProducer`
@@ -111,7 +103,6 @@ func NewProducer(configs *ProducerConfig) (kafka.Producer, error) {
 	p := &librdProducer{
 		config:          configs,
 		baseProducer:    producer,
-		adminClient:     admin,
 		partitionCounts: new(sync.Map),
 		mu:              &sync.RWMutex{},
 	}

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -23,6 +23,7 @@ type DeliveryReport interface {
 type ProducerErr interface {
 	error
 	RequiresRestart() bool
+	TxnRequiresAbort() bool
 }
 
 type ProducerProvider interface {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -35,6 +35,11 @@ func UnWrapRecursivelyUntil(err error, asserter func(unWrapped error) bool) erro
 		return nil
 	}
 
+	// Nothing to be unwrapped
+	if asserter(err) {
+		return err
+	}
+
 	unWrapped := errors.Unwrap(err)
 	if asserter(unWrapped) {
 		return unWrapped

--- a/streams/tasks/buffer.go
+++ b/streams/tasks/buffer.go
@@ -75,11 +75,11 @@ func newCommitBuffer(topology topology.SubTopology, producer kafka.Producer, ses
 
 func (b *commitBuffer) Init() error {
 	if err := b.producer.InitTransactions(context.Background()); err != nil {
-		b.handleTxError(b.logger, b.producer, err, `Buffer Init failed`)
+		b.handleTxError(b.logger, b.producer, err, `Buffer Init failed, cannot init transaction'`)
 	}
 
 	if err := b.producer.BeginTransaction(); err != nil {
-		b.handleTxError(b.logger, b.producer, err, `Buffer Init failed`)
+		b.handleTxError(b.logger, b.producer, err, `Buffer Init failed, cannot begin transaction`)
 	}
 
 	return nil

--- a/streams/tasks/buffer.go
+++ b/streams/tasks/buffer.go
@@ -22,6 +22,8 @@ type Buffer interface {
 	Close() error
 	Reset(dueTo error) error
 	Records() []*Record
+	Closing() bool
+	MarkAsCosing()
 }
 
 type BufferConfig struct {
@@ -48,6 +50,7 @@ type commitBuffer struct {
 	metrics struct {
 		batchSize metrics.Counter
 	}
+	closing bool
 
 	logger log.Logger
 }
@@ -72,11 +75,11 @@ func newCommitBuffer(topology topology.SubTopology, producer kafka.Producer, ses
 
 func (b *commitBuffer) Init() error {
 	if err := b.producer.InitTransactions(context.Background()); err != nil {
-		panic(err)
+		b.handleTxError(b.logger, b.producer, err, `Buffer Init failed`)
 	}
 
 	if err := b.producer.BeginTransaction(); err != nil {
-		panic(err)
+		b.handleTxError(b.logger, b.producer, err, `Buffer Init failed`)
 	}
 
 	return nil
@@ -175,7 +178,7 @@ func (b *commitBuffer) commit() error {
 
 func (b *commitBuffer) Reset(dueTo error) error {
 	b.logger.Warn(fmt.Sprintf(`Commit Buffer resetting due to %s...`, dueTo))
-	defer b.logger.Info(`Commit Buffer resetted`)
+	defer b.logger.Info(`Commit Buffer rested`)
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -187,17 +190,55 @@ func (b *commitBuffer) Reset(dueTo error) error {
 	}
 
 	if err := b.producer.AbortTransaction(context.Background()); err != nil {
-		return errors.Wrap(err, `transaction abort failed`)
+		b.handleTxError(b.logger, b.producer, err, `AbortTransaction error`)
+		goto OffsetReset // handleTxError will begin the transaction
 	}
 
 	if err := b.producer.BeginTransaction(); err != nil {
-		return errors.Wrap(err, `transaction begin failed`)
+		b.handleTxError(b.logger, b.producer, err, `BeginTransaction error`)
 	}
 
+OffsetReset:
 	b.offsetMap = map[string]kafka.ConsumerOffset{}
 	b.records = nil
 
 	return nil
+}
+
+func (b *commitBuffer) handleTxError(logger log.Logger, producer kafka.TransactionalProducer, err error, reason string) {
+	if b.closing {
+		logger.Warn(`handleTxError ignoring err (%s) due to CommitBuffer closing`)
+		return
+	}
+
+	producerErr := errors.UnWrapRecursivelyUntil(err, func(err error) bool {
+		_, ok := err.(kafka.ProducerErr)
+		return ok
+	})
+
+	if producerErr.(kafka.ProducerErr).TxnRequiresAbort() {
+		logger.Warn(fmt.Sprintf(`Transaction aborting. Reason:%s, Err:%s, retrying...`, reason, err))
+		if err := producer.AbortTransaction(nil); err != nil {
+			b.handleTxError(logger, producer, err, `tx abort failed`)
+		}
+	}
+
+	if ok := producerErr.(kafka.ProducerErr).RequiresRestart(); ok {
+		logger.Error(fmt.Sprintf(`Libkrkafka FATAL error restarting producer client. Reason:%s, Err:%s`, reason, err))
+
+		// Re-initiate producer client
+		if restartErr := producer.Restart(); restartErr != nil {
+			panic(restartErr)
+		}
+	}
+
+	if err := producer.InitTransactions(nil); err != nil {
+		b.handleTxError(logger, producer, err, `transaction init failed`)
+	}
+
+	if err := producer.BeginTransaction(); err != nil {
+		b.handleTxError(logger, producer, err, `transaction begin failed`)
+	}
 }
 
 func (b *commitBuffer) Close() error {
@@ -205,4 +246,12 @@ func (b *commitBuffer) Close() error {
 	defer b.logger.Info(`Commit Buffer closed`)
 
 	return b.Flush()
+}
+
+func (b *commitBuffer) Closing() bool {
+	return b.closing
+}
+
+func (b *commitBuffer) MarkAsCosing() {
+	b.closing = true
 }


### PR DESCRIPTION
Producer admin client removed
Transactional Producer incorrect retry after producer restart fixed TransactionalProducer error handling removed
TransactionalProducer TxnRequiresAbort() added
UnWrapRecursivelyUntil should return without unwrapping if error type matches assert func CommitBuffer transaction error handling added
Task should wait until consume processes stopped fixed